### PR TITLE
feat: extract and record actual swap output amount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,6 +2568,7 @@ dependencies = [
  "deadpool-diesel",
  "dex",
  "diesel",
+ "futures",
  "logging",
  "near-sdk",
  "once_cell",

--- a/crates/arbitrage/Cargo.toml
+++ b/crates/arbitrage/Cargo.toml
@@ -24,3 +24,4 @@ near-crypto = "0.34"
 near-primitives = "0.34"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+blockchain = { path = "../blockchain", features = ["test-utils"] }

--- a/crates/arbitrage/Cargo.toml
+++ b/crates/arbitrage/Cargo.toml
@@ -24,4 +24,4 @@ near-crypto = "0.34"
 near-primitives = "0.34"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-blockchain = { path = "../blockchain", features = ["test-utils"] }
+blockchain = { path = "../blockchain" }

--- a/crates/arbitrage/Cargo.toml
+++ b/crates/arbitrage/Cargo.toml
@@ -24,4 +24,4 @@ near-crypto = "0.34"
 near-primitives = "0.34"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-blockchain = { path = "../blockchain" }
+blockchain = { path = "../blockchain", features = ["mock"] }

--- a/crates/arbitrage/src/tests.rs
+++ b/crates/arbitrage/src/tests.rs
@@ -8,7 +8,9 @@ use humantime::parse_duration;
 use near_crypto::InMemorySigner;
 use near_primitives::action::Action;
 use near_primitives::types::BlockId;
-use near_primitives::views::{CallResult, ExecutionOutcomeView, FinalExecutionOutcomeViewEnum};
+use near_primitives::views::{
+    CallResult, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
+};
 use near_sdk::AccountId;
 use near_sdk::NearToken;
 use near_sdk::json_types::U128;
@@ -224,22 +226,13 @@ impl jsonrpc::SentTx for MockSentTx {
         unimplemented!()
     }
 
-    async fn wait_for_success(&self) -> crate::Result<ExecutionOutcomeView> {
+    async fn wait_for_success(&self) -> crate::Result<FinalExecutionOutcomeView> {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(ExecutionOutcomeView {
-            logs: vec![],
-            receipt_ids: vec![],
-            gas_burnt: near_primitives::types::Gas::from_gas(0),
-            tokens_burnt: NearToken::from_yoctonear(0),
-            executor_id: AccountId::try_from("test.near".to_string())?,
-            status: near_primitives::views::ExecutionStatusView::SuccessValue(vec![]),
-            metadata: near_primitives::views::ExecutionMetadataView {
-                version: 1,
-                gas_profile: None,
-            },
-        })
+        Ok(blockchain::test_utils::dummy_final_outcome(
+            b"\"0\"".to_vec(),
+        ))
     }
 }
 

--- a/crates/arbitrage/src/tests.rs
+++ b/crates/arbitrage/src/tests.rs
@@ -230,9 +230,7 @@ impl jsonrpc::SentTx for MockSentTx {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(blockchain::test_utils::dummy_final_outcome(
-            b"\"0\"".to_vec(),
-        ))
+        Ok(blockchain::mock::dummy_final_outcome(b"\"0\"".to_vec()))
     }
 }
 

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -32,6 +32,9 @@ futures-util = { workspace = true }
 reqwest = { workspace = true }
 rand = { workspace = true }
 
+[features]
+mock = []
+
 [dev-dependencies]
 assertables = "9.5"
 proptest = "1.6"

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -32,9 +32,6 @@ futures-util = { workspace = true }
 reqwest = { workspace = true }
 rand = { workspace = true }
 
-[features]
-test-utils = []
-
 [dev-dependencies]
 assertables = "9.5"
 proptest = "1.6"

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -32,6 +32,9 @@ futures-util = { workspace = true }
 reqwest = { workspace = true }
 rand = { workspace = true }
 
+[features]
+test-utils = []
+
 [dev-dependencies]
 assertables = "9.5"
 proptest = "1.6"

--- a/crates/blockchain/src/jsonrpc.rs
+++ b/crates/blockchain/src/jsonrpc.rs
@@ -17,7 +17,7 @@ use near_primitives::action::Action;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::BlockId;
 use near_primitives::views::{
-    AccessKeyView, BlockView, CallResult, ExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
+    AccessKeyView, BlockView, CallResult, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
     TxExecutionStatus,
 };
 use near_sdk::{AccountId, NearToken};
@@ -119,5 +119,5 @@ pub trait SendTx {
 
 pub trait SentTx {
     async fn wait_for_executed(&self) -> Result<FinalExecutionOutcomeViewEnum>;
-    async fn wait_for_success(&self) -> Result<ExecutionOutcomeView>;
+    async fn wait_for_success(&self) -> Result<FinalExecutionOutcomeView>;
 }

--- a/crates/blockchain/src/jsonrpc/sent_tx.rs
+++ b/crates/blockchain/src/jsonrpc/sent_tx.rs
@@ -4,7 +4,8 @@ use logging::*;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::AccountId;
 use near_primitives::views::{
-    ExecutionOutcomeView, FinalExecutionOutcomeViewEnum, FinalExecutionStatus, TxExecutionStatus,
+    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, FinalExecutionStatus,
+    TxExecutionStatus,
 };
 use std::time::Duration;
 
@@ -39,7 +40,7 @@ impl<A: TxInfo> SentTx for StandardSentTx<A> {
             .ok_or_else(|| anyhow!("No outcome of tx: {}", self.tx_hash))
     }
 
-    async fn wait_for_success(&self) -> crate::Result<ExecutionOutcomeView> {
+    async fn wait_for_success(&self) -> crate::Result<FinalExecutionOutcomeView> {
         let log = DEFAULT.new(o!(
             "function" => "wait_for_success",
             "tx_hash" => format!("{}", self.tx_hash),
@@ -117,7 +118,7 @@ impl<A: TxInfo> SentTx for StandardSentTx<A> {
                             attempt_log,
                             "transaction completed successfully and finalized"
                         );
-                        return Ok(view.transaction_outcome.outcome);
+                        return Ok(view);
                     }
                 }
             } else {

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod jsonrpc;
 pub mod ref_finance;
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 pub mod types;
 pub mod wallet;

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(async_fn_in_trait)]
 
 pub mod jsonrpc;
+#[cfg(any(test, feature = "mock"))]
 pub mod mock;
 pub mod ref_finance;
 pub mod types;

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod jsonrpc;
 pub mod ref_finance;
+pub mod test_utils;
 pub mod types;
 pub mod wallet;
 

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -2,9 +2,8 @@
 #![allow(async_fn_in_trait)]
 
 pub mod jsonrpc;
+pub mod mock;
 pub mod ref_finance;
-#[cfg(any(test, feature = "test-utils"))]
-pub mod test_utils;
 pub mod types;
 pub mod wallet;
 

--- a/crates/blockchain/src/mock.rs
+++ b/crates/blockchain/src/mock.rs
@@ -6,12 +6,12 @@ use near_primitives::views::{
 };
 use near_sdk::{AccountId, NearToken};
 
-/// Create a dummy `FinalExecutionOutcomeView` for tests.
+/// Create a dummy `FinalExecutionOutcomeView` with the given success value.
 ///
 /// `success_value` is the bytes stored in `FinalExecutionStatus::SuccessValue`.
 /// For REF Finance swap, this is typically a JSON-encoded `U128` like `b"\"12345\""`.
 pub fn dummy_final_outcome(success_value: Vec<u8>) -> FinalExecutionOutcomeView {
-    let account_id: AccountId = "test.near".parse().expect("valid account id");
+    let account_id: AccountId = "mock.near".parse().expect("valid account id");
     let outcome = ExecutionOutcomeView {
         logs: vec![],
         receipt_ids: vec![],

--- a/crates/blockchain/src/ref_finance/balances/tests.rs
+++ b/crates/blockchain/src/ref_finance/balances/tests.rs
@@ -3,7 +3,9 @@ use anyhow::anyhow;
 use common::config::ConfigResolver;
 use near_crypto::InMemorySigner;
 use near_primitives::transaction::Action;
-use near_primitives::views::{CallResult, ExecutionOutcomeView, FinalExecutionOutcomeViewEnum};
+use near_primitives::views::{
+    CallResult, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
+};
 use near_sdk::NearToken;
 use near_sdk::json_types::U128;
 use serde_json::json;
@@ -250,22 +252,11 @@ impl SentTx for MockSentTx {
         unimplemented!()
     }
 
-    async fn wait_for_success(&self) -> Result<ExecutionOutcomeView> {
+    async fn wait_for_success(&self) -> Result<FinalExecutionOutcomeView> {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(ExecutionOutcomeView {
-            logs: vec![],
-            receipt_ids: vec![],
-            gas_burnt: near_primitives::types::Gas::from_gas(0),
-            tokens_burnt: NearToken::from_yoctonear(0),
-            executor_id: AccountId::try_from("test.near".to_string())?,
-            status: near_primitives::views::ExecutionStatusView::SuccessValue(vec![]),
-            metadata: near_primitives::views::ExecutionMetadataView {
-                version: 1,
-                gas_profile: None,
-            },
-        })
+        Ok(crate::test_utils::dummy_final_outcome(b"\"0\"".to_vec()))
     }
 }
 

--- a/crates/blockchain/src/ref_finance/balances/tests.rs
+++ b/crates/blockchain/src/ref_finance/balances/tests.rs
@@ -256,7 +256,7 @@ impl SentTx for MockSentTx {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(crate::test_utils::dummy_final_outcome(b"\"0\"".to_vec()))
+        Ok(crate::mock::dummy_final_outcome(b"\"0\"".to_vec()))
     }
 }
 

--- a/crates/blockchain/src/ref_finance/deposit/tests.rs
+++ b/crates/blockchain/src/ref_finance/deposit/tests.rs
@@ -4,7 +4,9 @@ use crate::ref_finance::token_account::WNEAR_TOKEN;
 use anyhow::anyhow;
 use near_crypto::InMemorySigner;
 use near_primitives::transaction::Action;
-use near_primitives::views::{CallResult, ExecutionOutcomeView, FinalExecutionOutcomeViewEnum};
+use near_primitives::views::{
+    CallResult, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
+};
 use near_sdk::NearToken;
 use std::cell::Cell;
 use std::sync::{Arc, Mutex};
@@ -78,22 +80,11 @@ impl SentTx for MockSentTx {
         unimplemented!()
     }
 
-    async fn wait_for_success(&self) -> Result<ExecutionOutcomeView> {
+    async fn wait_for_success(&self) -> Result<FinalExecutionOutcomeView> {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(ExecutionOutcomeView {
-            logs: vec![],
-            receipt_ids: vec![],
-            gas_burnt: near_primitives::types::Gas::from_gas(0),
-            tokens_burnt: NearToken::from_yoctonear(0),
-            executor_id: AccountId::try_from("test.near".to_string())?,
-            status: near_primitives::views::ExecutionStatusView::SuccessValue(vec![]),
-            metadata: near_primitives::views::ExecutionMetadataView {
-                version: 1,
-                gas_profile: None,
-            },
-        })
+        Ok(crate::test_utils::dummy_final_outcome(b"\"0\"".to_vec()))
     }
 }
 

--- a/crates/blockchain/src/ref_finance/deposit/tests.rs
+++ b/crates/blockchain/src/ref_finance/deposit/tests.rs
@@ -84,7 +84,7 @@ impl SentTx for MockSentTx {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(crate::test_utils::dummy_final_outcome(b"\"0\"".to_vec()))
+        Ok(crate::mock::dummy_final_outcome(b"\"0\"".to_vec()))
     }
 }
 

--- a/crates/blockchain/src/ref_finance/storage/tests.rs
+++ b/crates/blockchain/src/ref_finance/storage/tests.rs
@@ -85,7 +85,7 @@ impl SentTx for MockSentTx {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(crate::test_utils::dummy_final_outcome(b"\"0\"".to_vec()))
+        Ok(crate::mock::dummy_final_outcome(b"\"0\"".to_vec()))
     }
 }
 

--- a/crates/blockchain/src/ref_finance/storage/tests.rs
+++ b/crates/blockchain/src/ref_finance/storage/tests.rs
@@ -4,7 +4,9 @@ use crate::ref_finance::token_account::WNEAR_TOKEN;
 use anyhow::anyhow;
 use near_crypto::InMemorySigner;
 use near_primitives::transaction::Action;
-use near_primitives::views::{CallResult, ExecutionOutcomeView, FinalExecutionOutcomeViewEnum};
+use near_primitives::views::{
+    CallResult, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
+};
 use near_sdk::NearToken;
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -79,22 +81,11 @@ impl SentTx for MockSentTx {
         unimplemented!()
     }
 
-    async fn wait_for_success(&self) -> Result<ExecutionOutcomeView> {
+    async fn wait_for_success(&self) -> Result<FinalExecutionOutcomeView> {
         if self.should_fail {
             return Err(anyhow!("Transaction failed"));
         }
-        Ok(ExecutionOutcomeView {
-            logs: vec![],
-            receipt_ids: vec![],
-            gas_burnt: near_primitives::types::Gas::from_gas(0),
-            tokens_burnt: NearToken::from_yoctonear(0),
-            executor_id: AccountId::try_from("test.near".to_string())?,
-            status: near_primitives::views::ExecutionStatusView::SuccessValue(vec![]),
-            metadata: near_primitives::views::ExecutionMetadataView {
-                version: 1,
-                gas_profile: None,
-            },
-        })
+        Ok(crate::test_utils::dummy_final_outcome(b"\"0\"".to_vec()))
     }
 }
 

--- a/crates/blockchain/src/ref_finance/swap.rs
+++ b/crates/blockchain/src/ref_finance/swap.rs
@@ -132,10 +132,10 @@ where
 /// parsing will fail with a `warn` log and the caller should treat the result as
 /// `None` (i.e. `actual_to_amount` = NULL in the database).
 pub fn extract_actual_output(view: &FinalExecutionOutcomeView) -> Result<u128> {
+    let log = DEFAULT.new(o!("function" => "extract_actual_output"));
     match &view.status {
         FinalExecutionStatus::SuccessValue(bytes) => {
             let amount: U128 = serde_json::from_slice(bytes).map_err(|e| {
-                let log = DEFAULT.new(o!("function" => "extract_actual_output"));
                 let raw_str = String::from_utf8_lossy(bytes);
                 let hex_str: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
                 warn!(log, "failed to parse SuccessValue as U128";

--- a/crates/blockchain/src/ref_finance/swap.rs
+++ b/crates/blockchain/src/ref_finance/swap.rs
@@ -3,6 +3,7 @@ use crate::wallet::Wallet;
 use crate::{Result, jsonrpc};
 use dex::{TokenPair, TokenPairLike};
 use logging::*;
+use near_primitives::views::{FinalExecutionOutcomeView, FinalExecutionStatus};
 use near_sdk::json_types::U128;
 use near_sdk::{AccountId, NearToken};
 use serde::{Deserialize, Serialize};
@@ -119,6 +120,24 @@ where
         .await?;
 
     Ok((tx_hash, out))
+}
+
+/// Extract the actual output amount from a successful swap transaction outcome.
+///
+/// REF Finance's `swap()` contract function returns the actual output amount as a
+/// JSON-encoded `U128` in `FinalExecutionStatus::SuccessValue`.
+pub fn extract_actual_output(view: &FinalExecutionOutcomeView) -> Result<u128> {
+    match &view.status {
+        FinalExecutionStatus::SuccessValue(bytes) => {
+            let amount: U128 = serde_json::from_slice(bytes)?;
+            Ok(amount.0)
+        }
+        FinalExecutionStatus::Failure(err) => Err(anyhow::anyhow!("Transaction failed: {:?}", err)),
+        _ => Err(anyhow::anyhow!(
+            "Transaction did not complete: {:?}",
+            view.status
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/crates/blockchain/src/ref_finance/swap.rs
+++ b/crates/blockchain/src/ref_finance/swap.rs
@@ -124,8 +124,13 @@ where
 
 /// Extract the actual output amount from a successful swap transaction outcome.
 ///
-/// REF Finance's `swap()` contract function returns the actual output amount as a
-/// JSON-encoded `U128` in `FinalExecutionStatus::SuccessValue`.
+/// # Contract assumption
+///
+/// REF Finance's `swap()` contract function returns the actual output token amount
+/// as a JSON-encoded `U128` in `FinalExecutionStatus::SuccessValue`, even for
+/// multi-hop swaps. If the contract changes this format (e.g. after an upgrade),
+/// parsing will fail with a `warn` log and the caller should treat the result as
+/// `None` (i.e. `actual_to_amount` = NULL in the database).
 pub fn extract_actual_output(view: &FinalExecutionOutcomeView) -> Result<u128> {
     match &view.status {
         FinalExecutionStatus::SuccessValue(bytes) => {

--- a/crates/blockchain/src/ref_finance/swap.rs
+++ b/crates/blockchain/src/ref_finance/swap.rs
@@ -129,7 +129,17 @@ where
 pub fn extract_actual_output(view: &FinalExecutionOutcomeView) -> Result<u128> {
     match &view.status {
         FinalExecutionStatus::SuccessValue(bytes) => {
-            let amount: U128 = serde_json::from_slice(bytes)?;
+            let amount: U128 = serde_json::from_slice(bytes).map_err(|e| {
+                let log = DEFAULT.new(o!("function" => "extract_actual_output"));
+                let raw_str = String::from_utf8_lossy(bytes);
+                let hex_str: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+                warn!(log, "failed to parse SuccessValue as U128";
+                    "error" => %e,
+                    "raw_bytes_utf8" => %raw_str,
+                    "raw_bytes_hex" => hex_str,
+                );
+                e
+            })?;
             Ok(amount.0)
         }
         FinalExecutionStatus::Failure(err) => Err(anyhow::anyhow!("Transaction failed: {:?}", err)),

--- a/crates/blockchain/src/ref_finance/swap/tests.rs
+++ b/crates/blockchain/src/ref_finance/swap/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::test_utils::dummy_final_outcome;
+use crate::mock::dummy_final_outcome;
 use common::types::TokenAccount;
 use common::types::{TokenInAccount, TokenOutAccount};
 use near_primitives::views::FinalExecutionStatus;

--- a/crates/blockchain/src/ref_finance/swap/tests.rs
+++ b/crates/blockchain/src/ref_finance/swap/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
+use crate::test_utils::dummy_final_outcome;
 use common::types::TokenAccount;
 use common::types::{TokenInAccount, TokenOutAccount};
+use near_primitives::views::FinalExecutionStatus;
 use near_sdk::require;
 
 struct MockTokenPair {
@@ -158,4 +160,36 @@ fn test_build_swap_actions_with_very_small_amounts() {
     assert_eq!(output, 0); // 1 * 0.9 = 0.9 → 0 (整数の切り捨て)
     assert_eq!(actions[0].amount_in, Some(U128(1)));
     assert_eq!(actions[0].min_amount_out.0, 5);
+}
+
+#[test]
+fn test_extract_actual_output_success() {
+    // REF Finance returns U128 as JSON-encoded string: "\"12345\""
+    let view = dummy_final_outcome(b"\"12345\"".to_vec());
+    let result = extract_actual_output(&view).unwrap();
+    assert_eq!(result, 12345);
+}
+
+#[test]
+fn test_extract_actual_output_zero() {
+    let view = dummy_final_outcome(b"\"0\"".to_vec());
+    let result = extract_actual_output(&view).unwrap();
+    assert_eq!(result, 0);
+}
+
+#[test]
+fn test_extract_actual_output_large_value() {
+    // Large u128 value typical of token amounts with 24 decimals
+    let value = "\"1000000000000000000000000\""; // 1e24
+    let view = dummy_final_outcome(value.as_bytes().to_vec());
+    let result = extract_actual_output(&view).unwrap();
+    assert_eq!(result, 1_000_000_000_000_000_000_000_000);
+}
+
+#[test]
+fn test_extract_actual_output_failure() {
+    let mut view = dummy_final_outcome(b"\"0\"".to_vec());
+    view.status = FinalExecutionStatus::NotStarted;
+    let result = extract_actual_output(&view);
+    assert!(result.is_err());
 }

--- a/crates/blockchain/src/ref_finance/swap/tests.rs
+++ b/crates/blockchain/src/ref_finance/swap/tests.rs
@@ -187,9 +187,23 @@ fn test_extract_actual_output_large_value() {
 }
 
 #[test]
-fn test_extract_actual_output_failure() {
+fn test_extract_actual_output_not_started() {
     let mut view = dummy_final_outcome(b"\"0\"".to_vec());
     view.status = FinalExecutionStatus::NotStarted;
+    let result = extract_actual_output(&view);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_extract_actual_output_invalid_json() {
+    let view = dummy_final_outcome(b"not valid json".to_vec());
+    let result = extract_actual_output(&view);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_extract_actual_output_empty_bytes() {
+    let view = dummy_final_outcome(vec![]);
     let result = extract_actual_output(&view);
     assert!(result.is_err());
 }

--- a/crates/blockchain/src/ref_finance/swap/tests.rs
+++ b/crates/blockchain/src/ref_finance/swap/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::mock::dummy_final_outcome;
 use common::types::TokenAccount;
 use common::types::{TokenInAccount, TokenOutAccount};
+use near_primitives::errors::{InvalidTxError, TxExecutionError};
 use near_primitives::views::FinalExecutionStatus;
 use near_sdk::require;
 
@@ -206,4 +207,20 @@ fn test_extract_actual_output_empty_bytes() {
     let view = dummy_final_outcome(vec![]);
     let result = extract_actual_output(&view);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_extract_actual_output_failure() {
+    let tx_error = TxExecutionError::InvalidTxError(InvalidTxError::InvalidSignerId {
+        signer_id: "bad".to_string(),
+    });
+    let mut view = dummy_final_outcome(b"\"0\"".to_vec());
+    view.status = FinalExecutionStatus::Failure(tx_error);
+    let result = extract_actual_output(&view);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Transaction failed"),
+        "unexpected error message: {err_msg}"
+    );
 }

--- a/crates/blockchain/src/test_utils.rs
+++ b/crates/blockchain/src/test_utils.rs
@@ -1,0 +1,47 @@
+use near_crypto::{KeyType, PublicKey, Signature};
+use near_primitives::hash::CryptoHash;
+use near_primitives::views::{
+    ExecutionMetadataView, ExecutionOutcomeView, ExecutionOutcomeWithIdView, ExecutionStatusView,
+    FinalExecutionOutcomeView, FinalExecutionStatus, SignedTransactionView,
+};
+use near_sdk::{AccountId, NearToken};
+
+/// Create a dummy `FinalExecutionOutcomeView` for tests.
+///
+/// `success_value` is the bytes stored in `FinalExecutionStatus::SuccessValue`.
+/// For REF Finance swap, this is typically a JSON-encoded `U128` like `b"\"12345\""`.
+pub fn dummy_final_outcome(success_value: Vec<u8>) -> FinalExecutionOutcomeView {
+    let account_id: AccountId = "test.near".parse().expect("valid account id");
+    let outcome = ExecutionOutcomeView {
+        logs: vec![],
+        receipt_ids: vec![],
+        gas_burnt: near_primitives::types::Gas::from_gas(0),
+        tokens_burnt: NearToken::from_yoctonear(0),
+        executor_id: account_id.clone(),
+        status: ExecutionStatusView::SuccessValue(success_value.clone()),
+        metadata: ExecutionMetadataView {
+            version: 1,
+            gas_profile: None,
+        },
+    };
+    FinalExecutionOutcomeView {
+        status: FinalExecutionStatus::SuccessValue(success_value),
+        transaction: SignedTransactionView {
+            signer_id: account_id.clone(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce: 0,
+            receiver_id: account_id,
+            actions: vec![],
+            priority_fee: 0,
+            signature: Signature::default(),
+            hash: CryptoHash::default(),
+        },
+        transaction_outcome: ExecutionOutcomeWithIdView {
+            proof: vec![],
+            block_hash: CryptoHash::default(),
+            id: CryptoHash::default(),
+            outcome,
+        },
+        receipts_outcome: vec![],
+    }
+}

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -22,6 +22,7 @@ slog = { workspace = true }
 mock = []
 
 [dev-dependencies]
+futures = { workspace = true }
 near-sdk = { version = "5.24", features = ["non-contract-usage"] }
 serial_test = "3.2"
 tokio = { workspace = true, features = ["full"] }

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -18,6 +18,9 @@ once_cell = { workspace = true }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 slog = { workspace = true }
 
+[features]
+mock = []
+
 [dev-dependencies]
 near-sdk = { version = "5.24", features = ["non-contract-usage"] }
 serial_test = "3.2"

--- a/crates/persistence/src/evaluation_period.rs
+++ b/crates/persistence/src/evaluation_period.rs
@@ -227,6 +227,8 @@ impl EvaluationPeriod {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::FutureExt;
+    use std::panic::AssertUnwindSafe;
 
     #[tokio::test]
     async fn test_create_and_get_evaluation_period() {
@@ -258,18 +260,26 @@ mod tests {
         let new_period = NewEvaluationPeriod::new(initial_value.clone(), vec![]);
 
         let created = new_period.insert_async().await.unwrap();
-        assert_eq!(created.initial_value, initial_value);
+        let period_id = created.period_id.clone();
 
-        // DB から再取得しても一致
-        let fetched = EvaluationPeriod::get_by_period_id_async(created.period_id.clone())
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(fetched.initial_value, initial_value);
+        let result = AssertUnwindSafe(async {
+            assert_eq!(created.initial_value, initial_value);
 
-        // Cleanup
-        EvaluationPeriod::delete_by_period_id_async(created.period_id)
-            .await
-            .unwrap();
+            // DB から再取得しても一致
+            let fetched = EvaluationPeriod::get_by_period_id_async(period_id.clone())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(fetched.initial_value, initial_value);
+        })
+        .catch_unwind()
+        .await;
+
+        // Cleanup（テスト本体がパニックしても常に実行）
+        let _ = EvaluationPeriod::delete_by_period_id_async(period_id).await;
+
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
     }
 }

--- a/crates/persistence/src/evaluation_period.rs
+++ b/crates/persistence/src/evaluation_period.rs
@@ -204,6 +204,23 @@ impl EvaluationPeriod {
 
         result.context("Failed to update selected tokens")
     }
+
+    /// period_idで評価期間を削除
+    pub async fn delete_by_period_id_async(period_id: String) -> Result<()> {
+        let conn = connection_pool::get().await?;
+
+        conn.interact(move |conn| {
+            diesel::delete(
+                evaluation_periods::table.filter(evaluation_periods::period_id.eq(&period_id)),
+            )
+            .execute(conn)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to interact with database: {}", e))?
+        .map_err(|e| anyhow::anyhow!("Failed to delete evaluation period: {}", e))?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -248,5 +265,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(fetched.initial_value, initial_value);
+
+        // Cleanup
+        EvaluationPeriod::delete_by_period_id_async(created.period_id)
+            .await
+            .unwrap();
     }
 }

--- a/crates/persistence/src/evaluation_period.rs
+++ b/crates/persistence/src/evaluation_period.rs
@@ -205,7 +205,8 @@ impl EvaluationPeriod {
         result.context("Failed to update selected tokens")
     }
 
-    /// period_idで評価期間を削除
+    /// period_idで評価期間を削除（テスト専用）
+    #[cfg(any(test, feature = "mock"))]
     pub async fn delete_by_period_id_async(period_id: String) -> Result<()> {
         let conn = connection_pool::get().await?;
 

--- a/crates/persistence/src/schema.rs
+++ b/crates/persistence/src/schema.rs
@@ -97,6 +97,7 @@ diesel::table! {
         to_amount -> Numeric,
         timestamp -> Timestamp,
         evaluation_period_id -> Nullable<Varchar>,
+        actual_to_amount -> Nullable<Numeric>,
     }
 }
 

--- a/crates/persistence/src/trade_transaction.rs
+++ b/crates/persistence/src/trade_transaction.rs
@@ -23,6 +23,8 @@ pub struct TradeTransaction {
     pub to_amount: TokenSmallestUnits,
     pub timestamp: NaiveDateTime,
     pub evaluation_period_id: Option<String>,
+    // Nullable カラムでは deserialize_as/serialize_as が Option と互換しないため
+    // BigDecimal を直接使用。呼び出し側で TokenSmallestUnits との変換を行う。
     pub actual_to_amount: Option<BigDecimal>,
 }
 

--- a/crates/persistence/src/trade_transaction.rs
+++ b/crates/persistence/src/trade_transaction.rs
@@ -23,6 +23,7 @@ pub struct TradeTransaction {
     pub to_amount: TokenSmallestUnits,
     pub timestamp: NaiveDateTime,
     pub evaluation_period_id: Option<String>,
+    pub actual_to_amount: Option<BigDecimal>,
 }
 
 impl TradeTransaction {

--- a/crates/persistence/src/trade_transaction/tests.rs
+++ b/crates/persistence/src/trade_transaction/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use bigdecimal::BigDecimal;
 use common::types::TokenSmallestUnits;
 
 #[tokio::test]
@@ -142,6 +143,64 @@ async fn test_transaction_with_evaluation_period_id() {
 
     // Cleanup
     TradeTransaction::delete_by_tx_id_async(tx_id)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_actual_to_amount_roundtrip() {
+    let batch_id = uuid::Uuid::new_v4().to_string();
+    let tx_id_with = format!("test_tx_actual_{}", uuid::Uuid::new_v4());
+    let tx_id_without = format!("test_tx_no_actual_{}", uuid::Uuid::new_v4());
+
+    let actual_value = BigDecimal::from(49_500_000_000_000_000_000_000_u128);
+
+    // actual_to_amount あり
+    let tx_with = TradeTransaction {
+        tx_id: tx_id_with.clone(),
+        trade_batch_id: batch_id.clone(),
+        from_token: "wrap.near".to_string(),
+        from_amount: TokenSmallestUnits::from_u128(1_000_000_000_000_000_000_000_000),
+        to_token: "akaia.tkn.near".to_string(),
+        to_amount: TokenSmallestUnits::from_u128(50_000_000_000_000_000_000_000),
+        timestamp: chrono::Utc::now().naive_utc(),
+        evaluation_period_id: None,
+        actual_to_amount: Some(actual_value.clone()),
+    };
+    tx_with.insert_async().await.unwrap();
+
+    // actual_to_amount なし
+    let tx_without = TradeTransaction {
+        tx_id: tx_id_without.clone(),
+        trade_batch_id: batch_id.clone(),
+        from_token: "wrap.near".to_string(),
+        from_amount: TokenSmallestUnits::from_u128(1_000_000_000_000_000_000_000_000),
+        to_token: "akaia.tkn.near".to_string(),
+        to_amount: TokenSmallestUnits::from_u128(50_000_000_000_000_000_000_000),
+        timestamp: chrono::Utc::now().naive_utc(),
+        evaluation_period_id: None,
+        actual_to_amount: None,
+    };
+    tx_without.insert_async().await.unwrap();
+
+    // 読み戻して検証
+    let found_with = TradeTransaction::find_by_tx_id_async(tx_id_with.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found_with.actual_to_amount, Some(actual_value));
+
+    let found_without = TradeTransaction::find_by_tx_id_async(tx_id_without.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found_without.actual_to_amount, None);
+
+    // Cleanup
+    TradeTransaction::delete_by_tx_id_async(tx_id_with)
+        .await
+        .unwrap();
+    TradeTransaction::delete_by_tx_id_async(tx_id_without)
         .await
         .unwrap();
 }

--- a/crates/persistence/src/trade_transaction/tests.rs
+++ b/crates/persistence/src/trade_transaction/tests.rs
@@ -15,6 +15,7 @@ async fn test_trade_transaction_crud() {
         to_amount: TokenSmallestUnits::from_u128(50_000_000_000_000_000_000_000),
         timestamp: chrono::Utc::now().naive_utc(),
         evaluation_period_id: None,
+        actual_to_amount: None,
     };
 
     let result = transaction.insert_async().await.unwrap();
@@ -74,6 +75,7 @@ async fn test_count_by_evaluation_period() {
             to_amount: TokenSmallestUnits::from_u128(50_000_000_000_000_000_000_000),
             timestamp: chrono::Utc::now().naive_utc(),
             evaluation_period_id: Some(period_id.clone()),
+            actual_to_amount: None,
         };
 
         transaction.insert_async().await.unwrap();
@@ -124,6 +126,7 @@ async fn test_transaction_with_evaluation_period_id() {
         to_amount: TokenSmallestUnits::from_u128(50_000_000_000_000_000_000_000),
         timestamp: chrono::Utc::now().naive_utc(),
         evaluation_period_id: Some(period_id.clone()),
+        actual_to_amount: None,
     };
 
     let result = transaction.insert_async().await.unwrap();

--- a/crates/persistence/src/trade_transaction/tests.rs
+++ b/crates/persistence/src/trade_transaction/tests.rs
@@ -101,6 +101,9 @@ async fn test_count_by_evaluation_period() {
             .await
             .unwrap();
     }
+    crate::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -139,10 +142,13 @@ async fn test_transaction_with_evaluation_period_id() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(found.evaluation_period_id, Some(period_id));
+    assert_eq!(found.evaluation_period_id, Some(period_id.clone()));
 
     // Cleanup
     TradeTransaction::delete_by_tx_id_async(tx_id)
+        .await
+        .unwrap();
+    crate::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
         .await
         .unwrap();
 }

--- a/crates/persistence/src/trade_transaction/tests.rs
+++ b/crates/persistence/src/trade_transaction/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use bigdecimal::BigDecimal;
 use common::types::TokenSmallestUnits;
+use futures::FutureExt;
+use std::panic::AssertUnwindSafe;
 
 #[tokio::test]
 async fn test_trade_transaction_crud() {
@@ -82,28 +84,32 @@ async fn test_count_by_evaluation_period() {
         transaction.insert_async().await.unwrap();
     }
 
-    // count_by_evaluation_period_asyncをテスト
-    let count = TradeTransaction::count_by_evaluation_period_async(period_id.clone())
-        .await
-        .unwrap();
-    assert_eq!(count, 3);
-
-    // 存在しないperiod_idの場合は0を返す
-    let count_non_existent =
-        TradeTransaction::count_by_evaluation_period_async("non_existent_period".to_string())
+    let result = AssertUnwindSafe(async {
+        // count_by_evaluation_period_asyncをテスト
+        let count = TradeTransaction::count_by_evaluation_period_async(period_id.clone())
             .await
             .unwrap();
-    assert_eq!(count_non_existent, 0);
+        assert_eq!(count, 3);
 
-    // Cleanup
-    for tx_id in tx_ids {
-        TradeTransaction::delete_by_tx_id_async(tx_id)
-            .await
-            .unwrap();
+        // 存在しないperiod_idの場合は0を返す
+        let count_non_existent =
+            TradeTransaction::count_by_evaluation_period_async("non_existent_period".to_string())
+                .await
+                .unwrap();
+        assert_eq!(count_non_existent, 0);
+    })
+    .catch_unwind()
+    .await;
+
+    // Cleanup（テスト本体がパニックしても常に実行）
+    for tx_id in &tx_ids {
+        let _ = TradeTransaction::delete_by_tx_id_async(tx_id.clone()).await;
     }
-    crate::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
-        .await
-        .unwrap();
+    let _ = crate::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id).await;
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }
 
 #[tokio::test]
@@ -133,24 +139,28 @@ async fn test_transaction_with_evaluation_period_id() {
         actual_to_amount: None,
     };
 
-    let result = transaction.insert_async().await.unwrap();
-    assert_eq!(result.tx_id, tx_id);
-    assert_eq!(result.evaluation_period_id, Some(period_id.clone()));
+    let result = AssertUnwindSafe(async {
+        let inserted = transaction.insert_async().await.unwrap();
+        assert_eq!(inserted.tx_id, tx_id);
+        assert_eq!(inserted.evaluation_period_id, Some(period_id.clone()));
 
-    // 取得して確認
-    let found = TradeTransaction::find_by_tx_id_async(tx_id.clone())
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(found.evaluation_period_id, Some(period_id.clone()));
+        // 取得して確認
+        let found = TradeTransaction::find_by_tx_id_async(tx_id.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.evaluation_period_id, Some(period_id.clone()));
+    })
+    .catch_unwind()
+    .await;
 
-    // Cleanup
-    TradeTransaction::delete_by_tx_id_async(tx_id)
-        .await
-        .unwrap();
-    crate::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
-        .await
-        .unwrap();
+    // Cleanup（テスト本体がパニックしても常に実行）
+    let _ = TradeTransaction::delete_by_tx_id_async(tx_id).await;
+    let _ = crate::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id).await;
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }
 
 #[tokio::test]
@@ -189,24 +199,28 @@ async fn test_actual_to_amount_roundtrip() {
     };
     tx_without.insert_async().await.unwrap();
 
-    // 読み戻して検証
-    let found_with = TradeTransaction::find_by_tx_id_async(tx_id_with.clone())
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(found_with.actual_to_amount, Some(actual_value));
+    let result = AssertUnwindSafe(async {
+        // 読み戻して検証
+        let found_with = TradeTransaction::find_by_tx_id_async(tx_id_with.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_with.actual_to_amount, Some(actual_value));
 
-    let found_without = TradeTransaction::find_by_tx_id_async(tx_id_without.clone())
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(found_without.actual_to_amount, None);
+        let found_without = TradeTransaction::find_by_tx_id_async(tx_id_without.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_without.actual_to_amount, None);
+    })
+    .catch_unwind()
+    .await;
 
-    // Cleanup
-    TradeTransaction::delete_by_tx_id_async(tx_id_with)
-        .await
-        .unwrap();
-    TradeTransaction::delete_by_tx_id_async(tx_id_without)
-        .await
-        .unwrap();
+    // Cleanup（テスト本体がパニックしても常に実行）
+    let _ = TradeTransaction::delete_by_tx_id_async(tx_id_with).await;
+    let _ = TradeTransaction::delete_by_tx_id_async(tx_id_without).await;
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }

--- a/crates/simulate/Cargo.toml
+++ b/crates/simulate/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 common = { path = "../common" }
 persistence = { path = "../persistence" }
 trade = { path = "../trade" }
-blockchain = { path = "../blockchain", features = ["test-utils"] }
+blockchain = { path = "../blockchain" }
 logging = { path = "../logging" }
 clap = { version = "4", features = ["derive"] }
 tokio = { workspace = true }

--- a/crates/simulate/Cargo.toml
+++ b/crates/simulate/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 common = { path = "../common" }
 persistence = { path = "../persistence" }
 trade = { path = "../trade" }
-blockchain = { path = "../blockchain" }
+blockchain = { path = "../blockchain", features = ["mock"] }
 logging = { path = "../logging" }
 clap = { version = "4", features = ["derive"] }
 tokio = { workspace = true }

--- a/crates/simulate/Cargo.toml
+++ b/crates/simulate/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 common = { path = "../common" }
 persistence = { path = "../persistence" }
 trade = { path = "../trade" }
-blockchain = { path = "../blockchain" }
+blockchain = { path = "../blockchain", features = ["test-utils"] }
 logging = { path = "../logging" }
 clap = { version = "4", features = ["derive"] }
 tokio = { workspace = true }

--- a/crates/simulate/src/mock_client.rs
+++ b/crates/simulate/src/mock_client.rs
@@ -292,9 +292,6 @@ impl ViewContract for SimulationClient {
     }
 }
 
-#[cfg(test)]
-mod tests;
-
 pub struct MockSentTx {
     output_amount: u128,
 }
@@ -315,3 +312,6 @@ impl SentTx for MockSentTx {
         Ok(blockchain::mock::dummy_final_outcome(value_json))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/simulate/src/mock_client.rs
+++ b/crates/simulate/src/mock_client.rs
@@ -4,14 +4,11 @@ use blockchain::ref_finance::swap::SwapAction;
 use blockchain::types::gas_price::GasPrice;
 use chrono::{DateTime, Utc};
 use logging::*;
-use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature};
+use near_crypto::InMemorySigner;
 use near_primitives::action::Action;
-use near_primitives::hash::CryptoHash;
 use near_primitives::types::BlockId;
 use near_primitives::views::{
-    CallResult, ExecutionMetadataView, ExecutionOutcomeView, ExecutionOutcomeWithIdView,
-    ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
-    FinalExecutionStatus, SignedTransactionView,
+    CallResult, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
 };
 use near_sdk::json_types::U128;
 use near_sdk::{AccountId, NearToken};
@@ -315,45 +312,6 @@ impl SentTx for MockSentTx {
 
     async fn wait_for_success(&self) -> anyhow::Result<FinalExecutionOutcomeView> {
         let value_json = serde_json::to_vec(&U128(self.output_amount))?;
-        Ok(dummy_final_outcome(value_json))
-    }
-}
-
-/// Create a dummy `FinalExecutionOutcomeView` for simulation.
-///
-/// This is a local copy to avoid depending on blockchain's `test-utils` feature.
-fn dummy_final_outcome(success_value: Vec<u8>) -> FinalExecutionOutcomeView {
-    let account_id: AccountId = "sim.near".parse().expect("valid account id");
-    let outcome = ExecutionOutcomeView {
-        logs: vec![],
-        receipt_ids: vec![],
-        gas_burnt: near_primitives::types::Gas::from_gas(0),
-        tokens_burnt: NearToken::from_yoctonear(0),
-        executor_id: account_id.clone(),
-        status: ExecutionStatusView::SuccessValue(success_value.clone()),
-        metadata: ExecutionMetadataView {
-            version: 1,
-            gas_profile: None,
-        },
-    };
-    FinalExecutionOutcomeView {
-        status: FinalExecutionStatus::SuccessValue(success_value),
-        transaction: SignedTransactionView {
-            signer_id: account_id.clone(),
-            public_key: PublicKey::empty(KeyType::ED25519),
-            nonce: 0,
-            receiver_id: account_id,
-            actions: vec![],
-            priority_fee: 0,
-            signature: Signature::default(),
-            hash: CryptoHash::default(),
-        },
-        transaction_outcome: ExecutionOutcomeWithIdView {
-            proof: vec![],
-            block_hash: CryptoHash::default(),
-            id: CryptoHash::default(),
-            outcome,
-        },
-        receipts_outcome: vec![],
+        Ok(blockchain::mock::dummy_final_outcome(value_json))
     }
 }

--- a/crates/simulate/src/mock_client.rs
+++ b/crates/simulate/src/mock_client.rs
@@ -4,10 +4,15 @@ use blockchain::ref_finance::swap::SwapAction;
 use blockchain::types::gas_price::GasPrice;
 use chrono::{DateTime, Utc};
 use logging::*;
-use near_crypto::InMemorySigner;
+use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature};
 use near_primitives::action::Action;
+use near_primitives::hash::CryptoHash;
 use near_primitives::types::BlockId;
-use near_primitives::views::{CallResult, FinalExecutionOutcomeViewEnum};
+use near_primitives::views::{
+    CallResult, ExecutionMetadataView, ExecutionOutcomeView, ExecutionOutcomeWithIdView,
+    ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum,
+    FinalExecutionStatus, SignedTransactionView,
+};
 use near_sdk::json_types::U128;
 use near_sdk::{AccountId, NearToken};
 use serde_json::json;
@@ -125,7 +130,7 @@ impl SendTx for SimulationClient {
         _receiver: &AccountId,
         _amount: NearToken,
     ) -> anyhow::Result<Self::Output> {
-        Ok(MockSentTx)
+        Ok(MockSentTx { output_amount: 0 })
     }
 
     async fn exec_contract<T>(
@@ -173,6 +178,10 @@ impl SendTx for SimulationClient {
                                 "token_out" => &token_out,
                                 "amount_out" => amount_out
                             );
+
+                            return Ok(MockSentTx {
+                                output_amount: amount_out,
+                            });
                         } else {
                             warn!(log, "swap output is zero, skipping";
                                 "token_in" => &token_in, "token_out" => &token_out
@@ -183,7 +192,7 @@ impl SendTx for SimulationClient {
             }
         }
 
-        Ok(MockSentTx)
+        Ok(MockSentTx { output_amount: 0 })
     }
 
     async fn send_tx(
@@ -192,7 +201,7 @@ impl SendTx for SimulationClient {
         _receiver: &AccountId,
         _actions: Vec<Action>,
     ) -> anyhow::Result<Self::Output> {
-        Ok(MockSentTx)
+        Ok(MockSentTx { output_amount: 0 })
     }
 }
 
@@ -289,11 +298,13 @@ impl ViewContract for SimulationClient {
 #[cfg(test)]
 mod tests;
 
-pub struct MockSentTx;
+pub struct MockSentTx {
+    output_amount: u128,
+}
 
 impl std::fmt::Display for MockSentTx {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MockSentTx(sim)")
+        write!(f, "MockSentTx(sim, output={})", self.output_amount)
     }
 }
 
@@ -302,11 +313,47 @@ impl SentTx for MockSentTx {
         unimplemented!("SimulationClient does not execute real transactions")
     }
 
-    async fn wait_for_success(
-        &self,
-    ) -> anyhow::Result<near_primitives::views::FinalExecutionOutcomeView> {
-        Ok(blockchain::test_utils::dummy_final_outcome(
-            b"\"0\"".to_vec(),
-        ))
+    async fn wait_for_success(&self) -> anyhow::Result<FinalExecutionOutcomeView> {
+        let value_json = serde_json::to_vec(&U128(self.output_amount))?;
+        Ok(dummy_final_outcome(value_json))
+    }
+}
+
+/// Create a dummy `FinalExecutionOutcomeView` for simulation.
+///
+/// This is a local copy to avoid depending on blockchain's `test-utils` feature.
+fn dummy_final_outcome(success_value: Vec<u8>) -> FinalExecutionOutcomeView {
+    let account_id: AccountId = "sim.near".parse().expect("valid account id");
+    let outcome = ExecutionOutcomeView {
+        logs: vec![],
+        receipt_ids: vec![],
+        gas_burnt: near_primitives::types::Gas::from_gas(0),
+        tokens_burnt: NearToken::from_yoctonear(0),
+        executor_id: account_id.clone(),
+        status: ExecutionStatusView::SuccessValue(success_value.clone()),
+        metadata: ExecutionMetadataView {
+            version: 1,
+            gas_profile: None,
+        },
+    };
+    FinalExecutionOutcomeView {
+        status: FinalExecutionStatus::SuccessValue(success_value),
+        transaction: SignedTransactionView {
+            signer_id: account_id.clone(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce: 0,
+            receiver_id: account_id,
+            actions: vec![],
+            priority_fee: 0,
+            signature: Signature::default(),
+            hash: CryptoHash::default(),
+        },
+        transaction_outcome: ExecutionOutcomeWithIdView {
+            proof: vec![],
+            block_hash: CryptoHash::default(),
+            id: CryptoHash::default(),
+            outcome,
+        },
+        receipts_outcome: vec![],
     }
 }

--- a/crates/simulate/src/mock_client.rs
+++ b/crates/simulate/src/mock_client.rs
@@ -7,7 +7,7 @@ use logging::*;
 use near_crypto::InMemorySigner;
 use near_primitives::action::Action;
 use near_primitives::types::BlockId;
-use near_primitives::views::{CallResult, ExecutionOutcomeView, FinalExecutionOutcomeViewEnum};
+use near_primitives::views::{CallResult, FinalExecutionOutcomeViewEnum};
 use near_sdk::json_types::U128;
 use near_sdk::{AccountId, NearToken};
 use serde_json::json;
@@ -302,18 +302,11 @@ impl SentTx for MockSentTx {
         unimplemented!("SimulationClient does not execute real transactions")
     }
 
-    async fn wait_for_success(&self) -> anyhow::Result<ExecutionOutcomeView> {
-        Ok(ExecutionOutcomeView {
-            logs: vec![],
-            receipt_ids: vec![],
-            gas_burnt: near_primitives::types::Gas::from_gas(0),
-            tokens_burnt: NearToken::from_yoctonear(0),
-            executor_id: AccountId::try_from("sim.near".to_string())?,
-            status: near_primitives::views::ExecutionStatusView::SuccessValue(vec![]),
-            metadata: near_primitives::views::ExecutionMetadataView {
-                version: 1,
-                gas_profile: None,
-            },
-        })
+    async fn wait_for_success(
+        &self,
+    ) -> anyhow::Result<near_primitives::views::FinalExecutionOutcomeView> {
+        Ok(blockchain::test_utils::dummy_final_outcome(
+            b"\"0\"".to_vec(),
+        ))
     }
 }

--- a/crates/simulate/src/mock_client/tests.rs
+++ b/crates/simulate/src/mock_client/tests.rs
@@ -374,14 +374,30 @@ async fn exec_contract_swap_none_amount_in_is_noop() {
 
 #[tokio::test]
 async fn mock_sent_tx_display() {
-    let tx = MockSentTx;
-    assert_eq!(format!("{tx}"), "MockSentTx(sim)");
+    let tx = MockSentTx { output_amount: 0 };
+    assert_eq!(format!("{tx}"), "MockSentTx(sim, output=0)");
+
+    let tx = MockSentTx {
+        output_amount: 12345,
+    };
+    assert_eq!(format!("{tx}"), "MockSentTx(sim, output=12345)");
 }
 
 #[tokio::test]
 async fn mock_sent_tx_wait_for_success_returns_ok() {
     use blockchain::jsonrpc::SentTx;
-    let tx = MockSentTx;
+    let tx = MockSentTx {
+        output_amount: 42000,
+    };
     let result = tx.wait_for_success().await;
     assert!(result.is_ok());
+
+    // Verify the output amount is encoded in the outcome
+    let outcome = result.unwrap();
+    if let near_primitives::views::FinalExecutionStatus::SuccessValue(val) = &outcome.status {
+        let decoded: near_sdk::json_types::U128 = serde_json::from_slice(val).unwrap();
+        assert_eq!(decoded.0, 42000);
+    } else {
+        panic!("expected SuccessValue status");
+    }
 }

--- a/crates/trade/Cargo.toml
+++ b/crates/trade/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 [dev-dependencies]
 assertables = "9.5"
 diesel = { version = "2.2", features = ["postgres"] }
+persistence = { path = "../persistence", features = ["mock"] }
 proptest = "1.6"
 serial_test = "3.2"
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/trade/src/harvest.rs
+++ b/crates/trade/src/harvest.rs
@@ -327,8 +327,8 @@ async fn execute_harvest_transfer(
             &from_token,
             from_amount,
             &to_token,
-            to_amount,
-            None, // harvest does not go through REF Finance swap
+            to_amount.clone(),
+            Some(to_amount), // harvest は 1:1 変換のため actual = estimated
         )
         .await?;
 

--- a/crates/trade/src/harvest.rs
+++ b/crates/trade/src/harvest.rs
@@ -321,14 +321,15 @@ async fn execute_harvest_transfer(
     let to_token: TokenOutAccount = NEAR_TOKEN.to_out();
 
     let recorder = TradeRecorder::new(period_id.to_string());
+    let actual_to_amount = Some(to_amount.clone()); // harvest は 1:1 変換のため actual = estimated
     recorder
         .record_trade(
             tx_hash, // 実際のトランザクションハッシュを使用
             &from_token,
             from_amount,
             &to_token,
-            to_amount.clone(),
-            Some(to_amount), // harvest は 1:1 変換のため actual = estimated
+            to_amount,
+            actual_to_amount,
         )
         .await?;
 

--- a/crates/trade/src/harvest.rs
+++ b/crates/trade/src/harvest.rs
@@ -328,6 +328,7 @@ async fn execute_harvest_transfer(
             from_amount,
             &to_token,
             to_amount,
+            None, // harvest does not go through REF Finance swap
         )
         .await?;
 

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -142,6 +142,58 @@ mod tests {
 
         assert_eq!(result.tx_id, tx_id);
         assert_eq!(result.trade_batch_id, batch_id);
+        // actual_to_amount が DB に正しく保存されていることを検証
+        let found =
+            persistence::trade_transaction::TradeTransaction::find_by_tx_id_async(tx_id.clone())
+                .await
+                .unwrap()
+                .unwrap();
+        assert!(found.actual_to_amount.is_some());
+        assert_eq!(
+            found.actual_to_amount.unwrap(),
+            BigDecimal::from(49_500_000_000_000_000_000_000_u128)
+        );
+
+        // Cleanup
+        persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_trade_recorder_without_actual_amount() {
+        use persistence::evaluation_period::NewEvaluationPeriod;
+
+        let initial_value = YoctoAmount::from_u128(100_000_000_000_000_000_000_000_000);
+        let new_period = NewEvaluationPeriod::new(initial_value, vec![]);
+        let created_period = new_period.insert_async().await.unwrap();
+        let period_id = created_period.period_id;
+
+        let recorder = TradeRecorder::new(period_id);
+
+        let tx_id = format!("test_tx_{}", Uuid::new_v4());
+        let from_token: TokenInAccount = "wrap.near".parse::<TokenAccount>().unwrap().into();
+        let to_token: TokenOutAccount = "akaia.tkn.near".parse::<TokenAccount>().unwrap().into();
+        let result = recorder
+            .record_trade(
+                tx_id.clone(),
+                &from_token,
+                token_amount(1_000_000_000_000_000_000_000_000, WNEAR_DECIMALS),
+                &to_token,
+                token_amount(50_000_000_000_000_000_000_000, TEST_TOKEN_DECIMALS),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // actual_to_amount が NULL として保存されていることを検証
+        let found =
+            persistence::trade_transaction::TradeTransaction::find_by_tx_id_async(tx_id.clone())
+                .await
+                .unwrap()
+                .unwrap();
+        assert!(found.actual_to_amount.is_none());
+        assert_eq!(result.tx_id, tx_id);
 
         // Cleanup
         persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id)

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use bigdecimal::{BigDecimal, Zero};
 use common::types::TokenAmount;
 use common::types::{TokenInAccount, TokenOutAccount};
 use logging::*;
@@ -36,12 +37,33 @@ impl TradeRecorder {
         from_amount: TokenAmount,
         to_token: &TokenOutAccount,
         to_amount: TokenAmount,
+        actual_to_amount: Option<TokenAmount>,
     ) -> Result<TradeTransaction> {
         let log = DEFAULT.new(o!("function" => "record_trade"));
         debug!(log, "recording trade"; "from_token" => %from_token, "to_token" => %to_token, "tx_id" => %tx_id);
 
         let from_smallest = from_amount.into_smallest_units();
-        let to_smallest = to_amount.into_smallest_units();
+        let to_smallest = to_amount.clone().into_smallest_units();
+
+        if let Some(ref actual) = actual_to_amount {
+            let estimated_whole = to_amount.to_whole();
+            let actual_whole = actual.to_whole();
+            let diff_pct = if !estimated_whole.is_zero() {
+                let diff = &actual_whole - &estimated_whole;
+                (&diff / &estimated_whole) * BigDecimal::from(100)
+            } else {
+                BigDecimal::from(0)
+            };
+            info!(log, "swap slippage";
+                "estimated" => %estimated_whole,
+                "actual" => %actual_whole,
+                "diff_pct" => %diff_pct,
+                "to_token" => %to_token
+            );
+        }
+
+        let actual_to_smallest: Option<BigDecimal> =
+            actual_to_amount.map(|a| a.into_smallest_units().into());
 
         debug!(log, "recording trade details";
             "from_amount" => %from_smallest,
@@ -60,7 +82,7 @@ impl TradeRecorder {
             to_amount: to_smallest,
             timestamp: chrono::Utc::now().naive_utc(),
             evaluation_period_id: Some(self.evaluation_period_id.clone()),
-            actual_to_amount: None,
+            actual_to_amount: actual_to_smallest,
         };
 
         let result = transaction
@@ -110,7 +132,11 @@ mod tests {
                 &from_token,
                 token_amount(1_000_000_000_000_000_000_000_000, WNEAR_DECIMALS), // 1 wNEAR
                 &to_token,
-                token_amount(50_000_000_000_000_000_000_000, TEST_TOKEN_DECIMALS), // 50000 tokens
+                token_amount(50_000_000_000_000_000_000_000, TEST_TOKEN_DECIMALS), // 50000 tokens (estimated)
+                Some(token_amount(
+                    49_500_000_000_000_000_000_000,
+                    TEST_TOKEN_DECIMALS,
+                )), // actual
             )
             .await
             .unwrap();

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -62,7 +62,7 @@ impl TradeRecorder {
                 let diff = actual_bd - estimated_bd;
                 let diff_pct = (&diff / estimated_bd * BigDecimal::from(100))
                     .with_scale_round(4, bigdecimal::RoundingMode::HalfUp);
-                info!(log, "swap slippage";
+                debug!(log, "swap slippage";
                     "estimated" => %estimated_bd,
                     "actual" => %actual_bd,
                     "diff_pct" => %diff_pct,

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -105,6 +105,8 @@ mod tests {
     use super::*;
     use bigdecimal::BigDecimal;
     use common::types::{TokenAccount, YoctoAmount};
+    use futures::FutureExt;
+    use std::panic::AssertUnwindSafe;
 
     // テスト用定数
     const WNEAR_DECIMALS: u8 = 24;
@@ -132,42 +134,51 @@ mod tests {
         let tx_id = format!("test_tx_{}", Uuid::new_v4());
         let from_token: TokenInAccount = "wrap.near".parse::<TokenAccount>().unwrap().into();
         let to_token: TokenOutAccount = "akaia.tkn.near".parse::<TokenAccount>().unwrap().into();
-        let result = recorder
-            .record_trade(
+
+        let result = AssertUnwindSafe(async {
+            let result = recorder
+                .record_trade(
+                    tx_id.clone(),
+                    &from_token,
+                    token_amount(1_000_000_000_000_000_000_000_000, WNEAR_DECIMALS), // 1 wNEAR
+                    &to_token,
+                    token_amount(50_000_000_000_000_000_000_000, TEST_TOKEN_DECIMALS), // 50000 tokens (estimated)
+                    Some(token_amount(
+                        49_500_000_000_000_000_000_000,
+                        TEST_TOKEN_DECIMALS,
+                    )), // actual
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.tx_id, tx_id);
+            assert_eq!(result.trade_batch_id, batch_id);
+            // actual_to_amount が DB に正しく保存されていることを検証
+            let found = persistence::trade_transaction::TradeTransaction::find_by_tx_id_async(
                 tx_id.clone(),
-                &from_token,
-                token_amount(1_000_000_000_000_000_000_000_000, WNEAR_DECIMALS), // 1 wNEAR
-                &to_token,
-                token_amount(50_000_000_000_000_000_000_000, TEST_TOKEN_DECIMALS), // 50000 tokens (estimated)
-                Some(token_amount(
-                    49_500_000_000_000_000_000_000,
-                    TEST_TOKEN_DECIMALS,
-                )), // actual
             )
             .await
+            .unwrap()
             .unwrap();
+            assert!(found.actual_to_amount.is_some());
+            assert_eq!(
+                found.actual_to_amount.unwrap(),
+                BigDecimal::from(49_500_000_000_000_000_000_000_u128)
+            );
+        })
+        .catch_unwind()
+        .await;
 
-        assert_eq!(result.tx_id, tx_id);
-        assert_eq!(result.trade_batch_id, batch_id);
-        // actual_to_amount が DB に正しく保存されていることを検証
-        let found =
-            persistence::trade_transaction::TradeTransaction::find_by_tx_id_async(tx_id.clone())
-                .await
-                .unwrap()
-                .unwrap();
-        assert!(found.actual_to_amount.is_some());
-        assert_eq!(
-            found.actual_to_amount.unwrap(),
-            BigDecimal::from(49_500_000_000_000_000_000_000_u128)
-        );
+        // Cleanup（テスト本体がパニックしても常に実行）
+        let _ =
+            persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id).await;
+        let _ =
+            persistence::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
+                .await;
 
-        // Cleanup
-        persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id)
-            .await
-            .unwrap();
-        persistence::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
-            .await
-            .unwrap();
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
     }
 
     #[tokio::test]
@@ -184,33 +195,42 @@ mod tests {
         let tx_id = format!("test_tx_{}", Uuid::new_v4());
         let from_token: TokenInAccount = "wrap.near".parse::<TokenAccount>().unwrap().into();
         let to_token: TokenOutAccount = "akaia.tkn.near".parse::<TokenAccount>().unwrap().into();
-        let result = recorder
-            .record_trade(
+
+        let result = AssertUnwindSafe(async {
+            let result = recorder
+                .record_trade(
+                    tx_id.clone(),
+                    &from_token,
+                    token_amount(1_000_000_000_000_000_000_000_000, WNEAR_DECIMALS),
+                    &to_token,
+                    token_amount(50_000_000_000_000_000_000_000, TEST_TOKEN_DECIMALS),
+                    None,
+                )
+                .await
+                .unwrap();
+
+            // actual_to_amount が NULL として保存されていることを検証
+            let found = persistence::trade_transaction::TradeTransaction::find_by_tx_id_async(
                 tx_id.clone(),
-                &from_token,
-                token_amount(1_000_000_000_000_000_000_000_000, WNEAR_DECIMALS),
-                &to_token,
-                token_amount(50_000_000_000_000_000_000_000, TEST_TOKEN_DECIMALS),
-                None,
             )
             .await
+            .unwrap()
             .unwrap();
+            assert!(found.actual_to_amount.is_none());
+            assert_eq!(result.tx_id, tx_id);
+        })
+        .catch_unwind()
+        .await;
 
-        // actual_to_amount が NULL として保存されていることを検証
-        let found =
-            persistence::trade_transaction::TradeTransaction::find_by_tx_id_async(tx_id.clone())
-                .await
-                .unwrap()
-                .unwrap();
-        assert!(found.actual_to_amount.is_none());
-        assert_eq!(result.tx_id, tx_id);
+        // Cleanup（テスト本体がパニックしても常に実行）
+        let _ =
+            persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id).await;
+        let _ =
+            persistence::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
+                .await;
 
-        // Cleanup
-        persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id)
-            .await
-            .unwrap();
-        persistence::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
-            .await
-            .unwrap();
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
     }
 }

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -60,6 +60,7 @@ impl TradeRecorder {
             to_amount: to_smallest,
             timestamp: chrono::Utc::now().naive_utc(),
             evaluation_period_id: Some(self.evaluation_period_id.clone()),
+            actual_to_amount: None,
         };
 
         let result = transaction

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -121,7 +121,7 @@ mod tests {
         let created_period = new_period.insert_async().await.unwrap();
         let period_id = created_period.period_id;
 
-        let recorder = TradeRecorder::new(period_id);
+        let recorder = TradeRecorder::new(period_id.clone());
         let batch_id = recorder.get_batch_id().to_string();
 
         let tx_id = format!("test_tx_{}", Uuid::new_v4());
@@ -160,6 +160,9 @@ mod tests {
         persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id)
             .await
             .unwrap();
+        persistence::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -171,7 +174,7 @@ mod tests {
         let created_period = new_period.insert_async().await.unwrap();
         let period_id = created_period.period_id;
 
-        let recorder = TradeRecorder::new(period_id);
+        let recorder = TradeRecorder::new(period_id.clone());
 
         let tx_id = format!("test_tx_{}", Uuid::new_v4());
         let from_token: TokenInAccount = "wrap.near".parse::<TokenAccount>().unwrap().into();
@@ -199,6 +202,9 @@ mod tests {
 
         // Cleanup
         persistence::trade_transaction::TradeTransaction::delete_by_tx_id_async(tx_id)
+            .await
+            .unwrap();
+        persistence::evaluation_period::EvaluationPeriod::delete_by_period_id_async(period_id)
             .await
             .unwrap();
     }

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -51,7 +51,12 @@ impl TradeRecorder {
 
         if let Some(ref actual_bd) = actual_to_smallest {
             let estimated_bd = to_smallest.as_bigdecimal();
-            if !estimated_bd.is_zero() {
+            if estimated_bd.is_zero() {
+                warn!(log, "skipping slippage calculation: estimated amount is zero";
+                    "actual" => %actual_bd,
+                    "to_token" => %to_token
+                );
+            } else {
                 // diff_pct > 0: actual > estimated (有利な約定)
                 // diff_pct < 0: actual < estimated (不利な約定 = スリッページ損)
                 let diff = actual_bd - estimated_bd;

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
-use bigdecimal::{BigDecimal, Zero};
+use bigdecimal::BigDecimal;
 use common::types::TokenAmount;
 use common::types::{TokenInAccount, TokenOutAccount};
 use logging::*;
+use num_traits::Zero;
 use uuid::Uuid;
 
 use persistence::trade_transaction::TradeTransaction;
@@ -43,27 +44,25 @@ impl TradeRecorder {
         debug!(log, "recording trade"; "from_token" => %from_token, "to_token" => %to_token, "tx_id" => %tx_id);
 
         let from_smallest = from_amount.into_smallest_units();
-        let to_smallest = to_amount.clone().into_smallest_units();
-
-        if let Some(ref actual) = actual_to_amount {
-            let estimated_whole = to_amount.to_whole();
-            let actual_whole = actual.to_whole();
-            let diff_pct = if !estimated_whole.is_zero() {
-                let diff = &actual_whole - &estimated_whole;
-                (&diff / &estimated_whole) * BigDecimal::from(100)
-            } else {
-                BigDecimal::from(0)
-            };
-            info!(log, "swap slippage";
-                "estimated" => %estimated_whole,
-                "actual" => %actual_whole,
-                "diff_pct" => %diff_pct,
-                "to_token" => %to_token
-            );
-        }
+        let to_smallest = to_amount.into_smallest_units();
 
         let actual_to_smallest: Option<BigDecimal> =
             actual_to_amount.map(|a| a.into_smallest_units().into());
+
+        if let Some(ref actual_bd) = actual_to_smallest {
+            let estimated_bd = to_smallest.as_bigdecimal();
+            if !estimated_bd.is_zero() {
+                let diff = actual_bd - estimated_bd;
+                let diff_pct = (&diff / estimated_bd * BigDecimal::from(100))
+                    .with_scale_round(4, bigdecimal::RoundingMode::HalfUp);
+                info!(log, "swap slippage";
+                    "estimated" => %estimated_bd,
+                    "actual" => %actual_bd,
+                    "diff_pct" => %diff_pct,
+                    "to_token" => %to_token
+                );
+            }
+        }
 
         debug!(log, "recording trade details";
             "from_amount" => %from_smallest,

--- a/crates/trade/src/recorder.rs
+++ b/crates/trade/src/recorder.rs
@@ -52,6 +52,8 @@ impl TradeRecorder {
         if let Some(ref actual_bd) = actual_to_smallest {
             let estimated_bd = to_smallest.as_bigdecimal();
             if !estimated_bd.is_zero() {
+                // diff_pct > 0: actual > estimated (有利な約定)
+                // diff_pct < 0: actual < estimated (不利な約定 = スリッページ損)
                 let diff = actual_bd - estimated_bd;
                 let diff_pct = (&diff / estimated_bd * BigDecimal::from(100))
                     .with_scale_round(4, bigdecimal::RoundingMode::HalfUp);

--- a/crates/trade/src/swap.rs
+++ b/crates/trade/src/swap.rs
@@ -223,30 +223,23 @@ where
 
     // 実績値を抽出
     let actual_to_amount = match blockchain::ref_finance::swap::extract_actual_output(&outcome) {
-        Ok(actual) => {
-            info!(log, "swap successful";
-                "from" => %from_token,
-                "to" => %to_token,
-                "input" => swap_amount,
-                "estimated_output" => out,
-                "actual_output" => actual,
-            );
-            Some(TokenAmount::from_smallest_units(
-                BigDecimal::from(actual),
-                to_decimals,
-            ))
-        }
+        Ok(actual) => Some(TokenAmount::from_smallest_units(
+            BigDecimal::from(actual),
+            to_decimals,
+        )),
         Err(e) => {
             warn!(log, "failed to extract actual output"; "error" => %e);
-            info!(log, "swap successful";
-                "from" => %from_token,
-                "to" => %to_token,
-                "input" => swap_amount,
-                "estimated_output" => out,
-            );
             None
         }
     };
+
+    info!(log, "swap successful";
+        "from" => %from_token,
+        "to" => %to_token,
+        "input" => swap_amount,
+        "estimated_output" => out,
+        "actual_output" => actual_to_amount.as_ref().map(|a| a.to_string()).unwrap_or_default(),
+    );
 
     let from_amount =
         TokenAmount::from_smallest_units(BigDecimal::from(swap_amount), from_decimals);

--- a/crates/trade/src/swap.rs
+++ b/crates/trade/src/swap.rs
@@ -207,24 +207,47 @@ where
     let (sent_tx, out) =
         blockchain::ref_finance::swap::run_swap(client, wallet, &path.0, arg).await?;
 
-    if let Err(e) = sent_tx.wait_for_success().await {
-        error!(log, "swap transaction failed"; "error" => %e);
-        return Err(anyhow::anyhow!("Swap transaction failed: {}", e));
-    }
+    let outcome = match sent_tx.wait_for_success().await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            error!(log, "swap transaction failed"; "error" => %e);
+            return Err(anyhow::anyhow!("Swap transaction failed: {}", e));
+        }
+    };
 
-    info!(log, "swap successful";
-        "from" => %from_token,
-        "to" => %to_token,
-        "input" => swap_amount,
-        "output" => out,
-    );
-
-    // トレード記録を保存
     // トークンの decimals を取得して TokenAmount を作成
     let from_decimals =
         crate::token_cache::get_token_decimals_cached(client, from_token.inner()).await?;
     let to_decimals =
         crate::token_cache::get_token_decimals_cached(client, to_token.inner()).await?;
+
+    // 実績値を抽出
+    let actual_to_amount = match blockchain::ref_finance::swap::extract_actual_output(&outcome) {
+        Ok(actual) => {
+            info!(log, "swap successful";
+                "from" => %from_token,
+                "to" => %to_token,
+                "input" => swap_amount,
+                "estimated_output" => out,
+                "actual_output" => actual,
+            );
+            Some(TokenAmount::from_smallest_units(
+                BigDecimal::from(actual),
+                to_decimals,
+            ))
+        }
+        Err(e) => {
+            warn!(log, "failed to extract actual output"; "error" => %e);
+            info!(log, "swap successful";
+                "from" => %from_token,
+                "to" => %to_token,
+                "input" => swap_amount,
+                "estimated_output" => out,
+            );
+            None
+        }
+    };
+
     let from_amount =
         TokenAmount::from_smallest_units(BigDecimal::from(swap_amount), from_decimals);
     let to_amount = TokenAmount::from_smallest_units(BigDecimal::from(out), to_decimals);
@@ -236,6 +259,7 @@ where
             from_amount,
             to_token,
             to_amount,
+            actual_to_amount,
         )
         .await?;
 

--- a/crates/trade/src/swap.rs
+++ b/crates/trade/src/swap.rs
@@ -244,7 +244,7 @@ where
         "to" => %to_token,
         "input" => swap_amount,
         "estimated_output" => out,
-        "actual_output" => actual_to_amount.as_ref().map(|a| a.to_string()).unwrap_or_default(),
+        "actual_output" => actual_to_amount.as_ref().map(|a| a.to_string()).unwrap_or_else(|| "N/A".to_string()),
     );
 
     let from_amount =

--- a/crates/trade/src/swap.rs
+++ b/crates/trade/src/swap.rs
@@ -223,10 +223,16 @@ where
 
     // 実績値を抽出
     let actual_to_amount = match blockchain::ref_finance::swap::extract_actual_output(&outcome) {
-        Ok(actual) => Some(TokenAmount::from_smallest_units(
-            BigDecimal::from(actual),
-            to_decimals,
-        )),
+        Ok(actual) => {
+            if actual == 0 {
+                warn!(log, "swap returned zero output amount";
+                    "from" => %from_token, "to" => %to_token);
+            }
+            Some(TokenAmount::from_smallest_units(
+                BigDecimal::from(actual),
+                to_decimals,
+            ))
+        }
         Err(e) => {
             warn!(log, "failed to extract actual output"; "error" => %e);
             None

--- a/migrations/2026-03-09-000000_add_actual_to_amount/down.sql
+++ b/migrations/2026-03-09-000000_add_actual_to_amount/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE trade_transactions DROP COLUMN actual_to_amount;

--- a/migrations/2026-03-09-000000_add_actual_to_amount/up.sql
+++ b/migrations/2026-03-09-000000_add_actual_to_amount/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE trade_transactions ADD COLUMN actual_to_amount NUMERIC;


### PR DESCRIPTION
## Summary
- スワップ実行後のブロックチェーンレスポンスから実際の出力量（`actual_to_amount`）を抽出し、`trade_transactions` テーブルに記録する機能を追加
- `SentTx::wait_for_success()` の戻り値を `FinalExecutionOutcomeView` に変更し、トランザクション結果全体を取得可能にした
- スリッページ（推定値と実績値の差分）をログ出力し、約定品質を可視化

## Changes
- `trade_transactions` に `actual_to_amount` カラムを追加（マイグレーション）
- `extract_actual_output()` でスワップ結果をパースし実際の出力量を取得
- harvest フローで実際の出力量を `record_trade` に渡すよう修正
- テストのクリーンアップを `catch_unwind` でパニック耐性に改善
- MockSentTx にスワップ出力量を持たせてテスト可能にした

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p trade -p persistence`
- [x] `extract_actual_output` の正常系・異常系テスト
- [x] `actual_to_amount` の DB ラウンドトリップテスト
- [x] テストクリーンアップがパニック時も実行されることを確認